### PR TITLE
Remove path.decode(); doesn't exist in Python3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## WIP
 
+- Fix Python3 string conversion (via @wy-z and @MadeOfMagicAndWires)
 - Add support for PyCharm 2016.2 (via @danielsuo)
 - Add support for Telegram for macOS (via @matti)
 - Add support for Paintbrush 2.1.2 (via @domenicbrosh)

--- a/mackup/config.py
+++ b/mackup/config.py
@@ -222,7 +222,7 @@ class Config(object):
         if sys.version_info[0] < 3:
             path = path.encode("utf-8")
         else:
-            path = path.decode("utf-8")
+            path = str(path)
 
         return path
 


### PR DESCRIPTION
Hey, spoke about this addition [here](https://github.com/lra/mackup/pull/855#issuecomment-243237710) as well, but figured it'd be easier if I just submitted a PR to you. 

Also took the liberty of adding a line to Changelog as per CONTRIBUTING.md, but if you don't like the presumptious addition of my own name I'll send a PR without it.